### PR TITLE
Estimation automatique des trajets et de la durée du chantier

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,14 +273,10 @@
                 
                 <div id="step-1" class="card">
                     <h2 style="margin-top:0">1) Infos chantier</h2>
-                    <div class="row3">
+                    <div class="row">
                         <div>
                             <label>Adresse (ville)</label>
                             <input id="ville" placeholder="Montpellier, Béziers, Sète…"/>
-                        </div>
-                        <div>
-                            <label>Distance estimée (km AR)</label>
-                            <input id="distance" type="number" min="0" value="20"/>
                         </div>
                         <div>
                             <label>Date souhaitée</label>
@@ -475,7 +471,9 @@
                         <div class="price" id="total-ttc">—</div>
                     </div>
                 </div>
-                
+
+                <div class="muted" style="margin-top:8px">Durée estimée : <span id="duration">—</span></div>
+
                 <table style="margin-top:10px">
                     <thead>
                         <tr>
@@ -515,42 +513,56 @@
         // Configuration
         const CATALOG = {
             "Maçonnerie": [
-                { id: 'dalle_beton', label: 'Dalle béton', unit: 'm²', rate: 95, min: 800 },
-                { id: 'ouverture_porteur', label: 'Ouverture mur porteur (IPN inclus)', unit: 'forfait', rate: 2800, min: 2800 },
-                { id: 'demolition_cloison', label: 'Démolition cloison', unit: 'm²', rate: 35, min: 300 },
-                { id: 'mur_agglo', label: 'Mur agglos 20', unit: 'm²', rate: 85, min: 600 },
-                { id: 'chape_liquide', label: 'Chape liquide', unit: 'm²', rate: 22, min: 400 },
-                { id: 'seuil_beton', label: 'Seuil béton', unit: 'ml', rate: 60, min: 240 }
+                { id: 'dalle_beton', label: 'Dalle béton', unit: 'm²', rate: 95, min: 800, hours: 0.5 },
+                { id: 'ouverture_porteur', label: 'Ouverture mur porteur (IPN inclus)', unit: 'forfait', rate: 2800, min: 2800, hours: 35 },
+                { id: 'demolition_cloison', label: 'Démolition cloison', unit: 'm²', rate: 35, min: 300, hours: 0.15 },
+                { id: 'mur_agglo', label: 'Mur agglos 20', unit: 'm²', rate: 85, min: 600, hours: 0.6 },
+                { id: 'chape_liquide', label: 'Chape liquide', unit: 'm²', rate: 22, min: 400, hours: 0.1 },
+                { id: 'seuil_beton', label: 'Seuil béton', unit: 'ml', rate: 60, min: 240, hours: 0.4 }
             ],
             "Plomberie": [
-                { id: 'reseau_ecs', label: 'Réseau eau chaude/froide', unit: 'ml', rate: 42, min: 350 },
-                { id: 'sdb_pack', label: 'Salle de bains — pack (hors meubles)', unit: 'm²', rate: 280, min: 2500 },
-                { id: 'wc_suspendu', label: 'WC suspendu — pose', unit: 'forfait', rate: 420, min: 420 },
-                { id: 'chauffe_eau_200', label: 'Chauffe‑eau 200 L — pose', unit: 'forfait', rate: 380, min: 380 },
-                { id: 'evac_eu', label: 'Évacuation EU', unit: 'ml', rate: 30, min: 180 }
+                { id: 'reseau_ecs', label: 'Réseau eau chaude/froide', unit: 'ml', rate: 42, min: 350, hours: 0.3 },
+                { id: 'sdb_pack', label: 'Salle de bains — pack (hors meubles)', unit: 'm²', rate: 280, min: 2500, hours: 0.8 },
+                { id: 'wc_suspendu', label: 'WC suspendu — pose', unit: 'forfait', rate: 420, min: 420, hours: 8 },
+                { id: 'chauffe_eau_200', label: 'Chauffe‑eau 200 L — pose', unit: 'forfait', rate: 380, min: 380, hours: 6 },
+                { id: 'evac_eu', label: 'Évacuation EU', unit: 'ml', rate: 30, min: 180, hours: 0.2 }
             ],
             "Électricité": [
-                { id: 'renov_t2', label: 'Rénovation électrique T2', unit: 'forfait', rate: 3200, min: 3200 },
-                { id: 'prise', label: 'Ajout prise', unit: 'u', rate: 55, min: 165 },
-                { id: 'spots', label: 'Spots encastrés', unit: 'u', rate: 65, min: 195 },
-                { id: 'tableau', label: 'Remplacement tableau', unit: 'forfait', rate: 450, min: 450 },
-                { id: 'point_lumineux', label: 'Point lumineux', unit: 'u', rate: 70, min: 140 }
+                { id: 'renov_t2', label: 'Rénovation électrique T2', unit: 'forfait', rate: 3200, min: 3200, hours: 40 },
+                { id: 'prise', label: 'Ajout prise', unit: 'u', rate: 55, min: 165, hours: 1 },
+                { id: 'spots', label: 'Spots encastrés', unit: 'u', rate: 65, min: 195, hours: 0.8 },
+                { id: 'tableau', label: 'Remplacement tableau', unit: 'forfait', rate: 450, min: 450, hours: 8 },
+                { id: 'point_lumineux', label: 'Point lumineux', unit: 'u', rate: 70, min: 140, hours: 0.5 }
             ],
             "Carrelage": [
-                { id: 'sol_interieur', label: 'Carrelage sol intérieur', unit: 'm²', rate: 55, min: 500 },
-                { id: 'terrasse', label: 'Terrasse carrelée', unit: 'm²', rate: 75, min: 800 },
-                { id: 'credence', label: 'Crédence cuisine', unit: 'm²', rate: 85, min: 200 },
-                { id: 'faience', label: 'Faïence murale', unit: 'm²', rate: 45, min: 300 }
+                { id: 'sol_interieur', label: 'Carrelage sol intérieur', unit: 'm²', rate: 55, min: 500, hours: 0.3 },
+                { id: 'terrasse', label: 'Terrasse carrelée', unit: 'm²', rate: 75, min: 800, hours: 0.4 },
+                { id: 'credence', label: 'Crédence cuisine', unit: 'm²', rate: 85, min: 200, hours: 0.2 },
+                { id: 'faience', label: 'Faïence murale', unit: 'm²', rate: 45, min: 300, hours: 0.25 }
             ],
             "Peinture": [
-                { id: 'murs_plafonds', label: 'Peinture murs & plafonds', unit: 'm²', rate: 14, min: 300 },
-                { id: 'boiseries_laque', label: 'Boiseries — laque', unit: 'm²', rate: 22, min: 220 },
-                { id: 'enduit_lissage', label: 'Enduit de lissage', unit: 'm²', rate: 12, min: 180 }
+                { id: 'murs_plafonds', label: 'Peinture murs & plafonds', unit: 'm²', rate: 14, min: 300, hours: 0.15 },
+                { id: 'boiseries_laque', label: 'Boiseries — laque', unit: 'm²', rate: 22, min: 220, hours: 0.2 },
+                { id: 'enduit_lissage', label: 'Enduit de lissage', unit: 'm²', rate: 12, min: 180, hours: 0.15 }
             ]
         };
 
         // Tâches éligibles à la TVA réduite (5,5 %)
         const TVA55_TASKS = new Set(['chauffe_eau_200']);
+
+        // Distances approximatives depuis Vailhauquès (km aller simple)
+        const CITY_DISTANCES = {
+            montpellier: 15,
+            beziers: 70,
+            sete: 45,
+            nimes: 85,
+            agde: 75
+        };
+        const FUEL_COST_PER_KM = 0.5;
+        const getDistanceFromCity = city => {
+            const key = (city || '').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+            return CITY_DISTANCES[key] || 20;
+        };
 
         // Variables globales
         let currentStep = 0;
@@ -614,6 +626,7 @@
                         option.dataset.unit = task.unit;
                         option.dataset.rate = task.rate;
                         option.dataset.min = task.min;
+                        option.dataset.hours = task.hours;
                         option.dataset.tva55 = TVA55_TASKS.has(task.id) ? '1' : '0';
                         taskSelect.appendChild(option);
                     });
@@ -688,6 +701,7 @@
                             unit: taskOption.dataset.unit,
                             rate: parseFloat(taskOption.dataset.rate),
                             min: parseFloat(taskOption.dataset.min),
+                            hours: parseFloat(taskOption.dataset.hours),
                             qty: qty,
                             tva55: taskOption.dataset.tva55 === '1'
                         });
@@ -701,7 +715,8 @@
         // Fonction de calcul des prix
         function updatePricing() {
             const tasks = readTasks();
-            let totalHT = 0;
+            let tasksTotal = 0;
+            let totalHours = 0;
             const rows = [];
 
             // Taux de majoration appliqué aux tâches en fonction des options
@@ -716,7 +731,7 @@
             // Calcul du prix des tâches avec majoration éventuelle
             tasks.forEach(task => {
                 let price = 0;
-                
+
                 switch (task.unit) {
                     case 'm²':
                     case 'ml':
@@ -736,19 +751,27 @@
                 // Répartir les options sur les tâches
                 price *= (1 + optionRate);
 
-                totalHT += price;
-                rows.push([`${task.trade} — ${task.label} (${task.qty} ${task.unit})`, price]);
+                const hours = task.unit === 'forfait' ? task.hours : task.hours * task.qty;
+                totalHours += hours;
+                tasksTotal += price;
+                rows.push({ description: `${task.trade} — ${task.label} (${task.qty} ${task.unit})`, price });
             });
 
-            // Facteurs d'accès (simplifiés)
-            const distance = parseFloat(byId('distance').value) || 0;
-            const travelCost = distance * 1.2; // 1.2€ par km
-            if (travelCost > 0) {
-                totalHT += travelCost;
-                rows.push([`Déplacement (${distance} km)`, travelCost]);
+            // Durée estimée du chantier
+            const days = totalHours > 0 ? Math.ceil(totalHours / 7) : 0;
+
+            // Coût des trajets
+            const distance = getDistanceFromCity(byId('ville').value);
+            const travelCost = distance * 2 * days * FUEL_COST_PER_KM;
+            if (travelCost > 0 && tasksTotal > 0) {
+                rows.forEach(row => {
+                    const share = (row.price / tasksTotal) * travelCost;
+                    row.price += share;
+                });
+                tasksTotal += travelCost;
             }
 
-            // Les options sont réparties équitablement sur les tâches, aucun ajout de ligne séparée
+            let totalHT = tasksTotal;
 
             // TVA
             const tvaMode = byId('tva_mode').value;
@@ -779,18 +802,19 @@
             byId('tva-rate').textContent = `${(tvaRate * 100).toFixed(1).replace(/\.0$/, '')}%`;
             byId('tva-amt').textContent = formatEUR(tvaAmount);
             byId('count-tasks').textContent = `${tasks.length} ${tasks.length > 1 ? 'tâches' : 'tâche'}`;
+            byId('duration').textContent = days > 0 ? `${days} ${days > 1 ? 'jours' : 'jour'}` : '—';
 
             // Mise à jour du tableau détaillé
             const rowsContainer = byId('rows');
             rowsContainer.innerHTML = '';
-            
-            rows.forEach(([description, amount]) => {
+
+            rows.forEach(row => {
                 const tr = document.createElement('tr');
                 const td1 = document.createElement('td');
-                td1.textContent = description;
+                td1.textContent = row.description;
                 const td2 = document.createElement('td');
                 td2.className = 'right';
-                td2.textContent = formatEUR(amount);
+                td2.textContent = formatEUR(row.price);
                 tr.appendChild(td1);
                 tr.appendChild(td2);
                 rowsContainer.appendChild(tr);
@@ -806,8 +830,8 @@
         });
         const logement2ansEl = byId('logement_2ans');
         if (logement2ansEl) logement2ansEl.addEventListener('change', updatePricing);
-        const distanceEl = byId('distance');
-        if (distanceEl) distanceEl.addEventListener('input', updatePricing);
+        const villeEl = byId('ville');
+        if (villeEl) villeEl.addEventListener('input', updatePricing);
         addTaskRow();
 
     </script>


### PR DESCRIPTION
## Summary
- Supprime le champ de distance et affiche une durée de chantier estimée
- Ajoute des durées unitaires aux tâches et calcule le coût des trajets depuis Vailhauquès
- Répartit le coût d'essence sur les prix des tâches

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b98ccc18832a9fcb35edee1074e5