### PR TITLE
feat: enrich trade catalog

### DIFF
--- a/index.html
+++ b/index.html
@@ -518,37 +518,104 @@
                 { id: 'demolition_cloison', label: 'Démolition cloison', unit: 'm²', rate: 35, min: 300, hours: 0.15 },
                 { id: 'mur_agglo', label: 'Mur agglos 20', unit: 'm²', rate: 85, min: 600, hours: 0.6 },
                 { id: 'chape_liquide', label: 'Chape liquide', unit: 'm²', rate: 22, min: 400, hours: 0.1 },
-                { id: 'seuil_beton', label: 'Seuil béton', unit: 'ml', rate: 60, min: 240, hours: 0.4 }
+                { id: 'seuil_beton', label: 'Seuil béton', unit: 'ml', rate: 60, min: 240, hours: 0.4 },
+                { id: 'fondations_semelles', label: 'Fondations semelles filantes', unit: 'ml', rate: 120, min: 600, hours: 0.8 },
+                { id: 'muret_cloture', label: 'Muret de clôture', unit: 'ml', rate: 95, min: 500, hours: 0.6 },
+                { id: 'ragreage_sol', label: 'Ragréage sol', unit: 'm²', rate: 18, min: 250, hours: 0.1 }
             ],
             "Plomberie": [
                 { id: 'reseau_ecs', label: 'Réseau eau chaude/froide', unit: 'ml', rate: 42, min: 350, hours: 0.3 },
                 { id: 'sdb_pack', label: 'Salle de bains — pack (hors meubles)', unit: 'm²', rate: 280, min: 2500, hours: 0.8 },
                 { id: 'wc_suspendu', label: 'WC suspendu — pose', unit: 'forfait', rate: 420, min: 420, hours: 8 },
                 { id: 'chauffe_eau_200', label: 'Chauffe‑eau 200 L — pose', unit: 'forfait', rate: 380, min: 380, hours: 6 },
-                { id: 'evac_eu', label: 'Évacuation EU', unit: 'ml', rate: 30, min: 180, hours: 0.2 }
+                { id: 'evac_eu', label: 'Évacuation EU', unit: 'ml', rate: 30, min: 180, hours: 0.2 },
+                { id: 'receveur_douche', label: 'Receveur de douche — pose', unit: 'forfait', rate: 380, min: 380, hours: 7 },
+                { id: 'chaudiere_gaz', label: 'Chaudière gaz condensation — pose', unit: 'forfait', rate: 2500, min: 2500, hours: 30 },
+                { id: 'raccordement_evier', label: 'Raccordement évier cuisine', unit: 'forfait', rate: 180, min: 180, hours: 3 }
             ],
             "Électricité": [
                 { id: 'renov_t2', label: 'Rénovation électrique T2', unit: 'forfait', rate: 3200, min: 3200, hours: 40 },
                 { id: 'prise', label: 'Ajout prise', unit: 'u', rate: 55, min: 165, hours: 1 },
                 { id: 'spots', label: 'Spots encastrés', unit: 'u', rate: 65, min: 195, hours: 0.8 },
                 { id: 'tableau', label: 'Remplacement tableau', unit: 'forfait', rate: 450, min: 450, hours: 8 },
-                { id: 'point_lumineux', label: 'Point lumineux', unit: 'u', rate: 70, min: 140, hours: 0.5 }
+                { id: 'point_lumineux', label: 'Point lumineux', unit: 'u', rate: 70, min: 140, hours: 0.5 },
+                { id: 'vmc_simple', label: 'VMC simple flux', unit: 'forfait', rate: 850, min: 850, hours: 16 },
+                { id: 'prise_exterieure', label: 'Prise extérieure étanche', unit: 'u', rate: 80, min: 160, hours: 0.8 },
+                { id: 'mise_terre', label: 'Mise à la terre complète', unit: 'forfait', rate: 650, min: 650, hours: 14 }
             ],
             "Carrelage": [
                 { id: 'sol_interieur', label: 'Carrelage sol intérieur', unit: 'm²', rate: 55, min: 500, hours: 0.3 },
                 { id: 'terrasse', label: 'Terrasse carrelée', unit: 'm²', rate: 75, min: 800, hours: 0.4 },
                 { id: 'credence', label: 'Crédence cuisine', unit: 'm²', rate: 85, min: 200, hours: 0.2 },
-                { id: 'faience', label: 'Faïence murale', unit: 'm²', rate: 45, min: 300, hours: 0.25 }
+                { id: 'faience', label: 'Faïence murale', unit: 'm²', rate: 45, min: 300, hours: 0.25 },
+                { id: 'plinthes_carrelage', label: 'Plinthes assorties', unit: 'ml', rate: 15, min: 120, hours: 0.05 },
+                { id: 'escalier_carrelage', label: 'Escalier carrelé', unit: 'u', rate: 110, min: 330, hours: 2 },
+                { id: 'pose_mosaique', label: 'Pose mosaïque', unit: 'm²', rate: 95, min: 200, hours: 0.3 }
             ],
             "Peinture": [
                 { id: 'murs_plafonds', label: 'Peinture murs & plafonds', unit: 'm²', rate: 14, min: 300, hours: 0.15 },
                 { id: 'boiseries_laque', label: 'Boiseries — laque', unit: 'm²', rate: 22, min: 220, hours: 0.2 },
-                { id: 'enduit_lissage', label: 'Enduit de lissage', unit: 'm²', rate: 12, min: 180, hours: 0.15 }
+                { id: 'enduit_lissage', label: 'Enduit de lissage', unit: 'm²', rate: 12, min: 180, hours: 0.15 },
+                { id: 'peinture_facade', label: 'Peinture de façade', unit: 'm²', rate: 28, min: 600, hours: 0.25 },
+                { id: 'papier_peint', label: 'Pose papier peint', unit: 'm²', rate: 20, min: 200, hours: 0.2 },
+                { id: 'peinture_anti_humidite', label: 'Peinture anti-humidité', unit: 'm²', rate: 18, min: 180, hours: 0.18 }
+            ],
+            "Menuiserie": [
+                { id: 'porte_interieure', label: 'Porte intérieure — pose', unit: 'u', rate: 110, min: 220, hours: 3 },
+                { id: 'fenetre_pvc', label: 'Fenêtre PVC double vitrage', unit: 'u', rate: 450, min: 450, hours: 8 },
+                { id: 'volet_roulant', label: 'Volet roulant motorisé', unit: 'u', rate: 500, min: 500, hours: 5 },
+                { id: 'parquet_flottant', label: 'Parquet flottant', unit: 'm²', rate: 35, min: 300, hours: 0.25 },
+                { id: 'placard_sur_mesure', label: 'Placard sur mesure', unit: 'ml', rate: 300, min: 600, hours: 6 }
+            ],
+            "Plâtrerie": [
+                { id: 'cloison_ba13', label: 'Cloison BA13 sur ossature', unit: 'm²', rate: 45, min: 350, hours: 0.3 },
+                { id: 'doublage_isolant', label: 'Doublage isolant', unit: 'm²', rate: 40, min: 320, hours: 0.25 },
+                { id: 'plafond_suspendu', label: 'Plafond suspendu', unit: 'm²', rate: 55, min: 400, hours: 0.4 },
+                { id: 'corniche_staff', label: 'Corniche staff', unit: 'ml', rate: 25, min: 150, hours: 0.1 },
+                { id: 'joint_placo', label: 'Joint placo', unit: 'ml', rate: 3, min: 100, hours: 0.02 }
+            ],
+            "Couverture": [
+                { id: 'toiture_tuile', label: 'Toiture tuiles neuve', unit: 'm²', rate: 85, min: 1500, hours: 0.6 },
+                { id: 'reparation_fuite', label: 'Réparation fuite toiture', unit: 'forfait', rate: 450, min: 450, hours: 6 },
+                { id: 'pose_gouttiere', label: 'Pose gouttière zinc', unit: 'ml', rate: 35, min: 210, hours: 0.25 },
+                { id: 'demoussage_toiture', label: 'Démoussage toiture', unit: 'm²', rate: 12, min: 300, hours: 0.1 },
+                { id: 'reprise_faitiere', label: 'Reprise faîtière', unit: 'ml', rate: 65, min: 325, hours: 0.4 }
+            ],
+            "Isolation": [
+                { id: 'isolation_combles', label: 'Isolation combles laine soufflée', unit: 'm²', rate: 25, min: 500, hours: 0.2 },
+                { id: 'isolation_murs', label: 'Isolation murs intérieurs', unit: 'm²', rate: 35, min: 400, hours: 0.25 },
+                { id: 'isolation_plancher', label: 'Isolation plancher bas', unit: 'm²', rate: 30, min: 300, hours: 0.25 },
+                { id: 'isolation_exterieure', label: 'Isolation extérieure polystyrène', unit: 'm²', rate: 95, min: 1500, hours: 0.6 },
+                { id: 'etancheite_air', label: "Étanchéité à l'air — membrane", unit: 'm²', rate: 18, min: 200, hours: 0.1 }
+            ],
+            "Climatisation": [
+                { id: 'clim_monosplit', label: 'Climatiseur monosplit — pose', unit: 'forfait', rate: 1100, min: 1100, hours: 18 },
+                { id: 'clim_multisplit', label: 'Climatiseur multisplit — pose', unit: 'forfait', rate: 2200, min: 2200, hours: 40 },
+                { id: 'entretien_clim', label: 'Entretien climatisation', unit: 'forfait', rate: 120, min: 120, hours: 2 },
+                { id: 'pompe_a_chaleur', label: 'Pompe à chaleur air/eau', unit: 'forfait', rate: 8500, min: 8500, hours: 80 },
+                { id: 'vmc_double_flux', label: 'VMC double flux', unit: 'forfait', rate: 3200, min: 3200, hours: 35 }
+            ],
+            "Terrassement": [
+                { id: 'decaissement', label: 'Décaissement terrain', unit: 'm²', rate: 12, min: 400, hours: 0.2 },
+                { id: 'tranchee_technique', label: 'Tranchée technique', unit: 'ml', rate: 30, min: 300, hours: 0.25 },
+                { id: 'drainage_peripherique', label: 'Drainage périphérique', unit: 'ml', rate: 40, min: 400, hours: 0.4 },
+                { id: 'evacuation_deblais', label: 'Évacuation des déblais', unit: 'm²', rate: 20, min: 300, hours: 0.3 },
+                { id: 'remblaiement', label: 'Remblaiement', unit: 'm²', rate: 8, min: 200, hours: 0.1 }
             ]
         };
 
         // Tâches éligibles à la TVA réduite (5,5 %)
-        const TVA55_TASKS = new Set(['chauffe_eau_200']);
+        const TVA55_TASKS = new Set([
+            'chauffe_eau_200',
+            'chaudiere_gaz',
+            'isolation_combles',
+            'isolation_murs',
+            'isolation_plancher',
+            'isolation_exterieure',
+            'etancheite_air',
+            'pompe_a_chaleur',
+            'vmc_double_flux'
+        ]);
 
         // Distances approximatives depuis Vailhauquès (km aller simple)
         const CITY_DISTANCES = {


### PR DESCRIPTION
## Summary
- expand masonry, plumbing, electrical, tiling and painting trades with additional tasks
- add new trades: Menuiserie, Plâtrerie, Couverture, Isolation, Climatisation, Terrassement
- mark energy-efficiency tasks as eligible for reduced VAT

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0bee489e4832ab920bfd7aa7e9d5e