### PR TITLE
Enable distance lookup for all Hérault communes

### DIFF
--- a/index.html
+++ b/index.html
@@ -625,11 +625,33 @@
             nimes: 85,
             agde: 75
         };
+        const BASE_COORDS = { lat: 43.65, lon: 3.72 }; // Vailhauquès approximatif
         const FUEL_COST_PER_KM = 0.5;
-        const getDistanceFromCity = city => {
+        async function getDistanceFromCity(city) {
             const key = (city || '').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
-            return CITY_DISTANCES[key] || 20;
-        };
+            if (CITY_DISTANCES[key]) return CITY_DISTANCES[key];
+            try {
+                const res = await fetch(`https://api-adresse.data.gouv.fr/search/?q=${encodeURIComponent(city + ' (34)')}&limit=1&autocomplete=0`);
+                if (res.ok) {
+                    const data = await res.json();
+                    const feature = data.features && data.features[0];
+                    if (feature) {
+                        const [lon, lat] = feature.geometry.coordinates;
+                        const R = 6371; // Rayon terrestre en km
+                        const dLat = (lat - BASE_COORDS.lat) * Math.PI / 180;
+                        const dLon = (lon - BASE_COORDS.lon) * Math.PI / 180;
+                        const a = Math.sin(dLat / 2) ** 2 + Math.cos(BASE_COORDS.lat * Math.PI / 180) * Math.cos(lat * Math.PI / 180) * Math.sin(dLon / 2) ** 2;
+                        const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+                        const dist = Math.round(R * c);
+                        CITY_DISTANCES[key] = dist;
+                        return dist;
+                    }
+                }
+            } catch (e) {
+                console.error('Erreur distance', e);
+            }
+            return 20;
+        }
 
         // Variables globales
         let currentStep = 0;
@@ -780,7 +802,7 @@
         }
 
         // Fonction de calcul des prix
-        function updatePricing() {
+        async function updatePricing() {
             const tasks = readTasks();
             let tasksTotal = 0;
             let totalHours = 0;
@@ -828,7 +850,7 @@
             const days = totalHours > 0 ? Math.ceil(totalHours / 7) : 0;
 
             // Coût des trajets
-            const distance = getDistanceFromCity(byId('ville').value);
+            const distance = await getDistanceFromCity(byId('ville').value);
             const travelCost = distance * 2 * days * FUEL_COST_PER_KM;
             if (travelCost > 0 && tasksTotal > 0) {
                 rows.forEach(row => {


### PR DESCRIPTION
## Summary
- fetch commune coordinates from api-adresse when distance is missing
- compute travel distances from Vailhauquès base and cache results
- make pricing calculation async to include fetched distances

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0c0faee94832aae3ecd66d8c36621