### PR TITLE
Enable PDF download

### DIFF
--- a/index.html
+++ b/index.html
@@ -964,6 +964,20 @@
             });
         }
 
+        const btnPdf = byId('btn-pdf');
+        if (btnPdf) {
+            btnPdf.addEventListener('click', async function () {
+                await updatePricing();
+                buildRecap();
+                const { jsPDF } = window.jspdf;
+                const doc = new jsPDF();
+                const text = byId('recap').innerText;
+                const lines = doc.splitTextToSize(text, 180);
+                doc.text(lines, 10, 10);
+                doc.save('devis.pdf');
+            });
+        }
+
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enable PDF download by generating recap with jsPDF

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0e04d154c832a873b3b9aaecb566e