### PR TITLE
feat: improve PDF layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -713,6 +713,7 @@
 
         // Variables globales
         let currentStep = 0;
+        let pdfRows = [];
         // Helper functions
         const formatEUR = n => (n || 0).toLocaleString('fr-FR', { style: 'currency', currency: 'EUR' });
         const byId = id => document.getElementById(id);
@@ -901,7 +902,7 @@
                 const hours = task.unit === 'forfait' ? task.hours : task.hours * task.qty;
                 totalHours += hours;
                 tasksTotal += price;
-                rows.push({ description: `${task.trade} — ${task.label} (${task.qty} ${task.unit})`, price });
+                rows.push({ description: `${task.trade} — ${task.label}`, qty: task.unit === 'forfait' ? 1 : task.qty, unit: task.unit, price });
             });
 
             // Durée estimée du chantier
@@ -942,6 +943,13 @@
             const tvaAmount = totalHT * tvaRate;
             const totalTTC = totalHT + tvaAmount;
 
+            pdfRows = rows.map(r => ({
+                description: r.description,
+                qty: r.qty,
+                unitPrice: r.price / (r.qty || 1),
+                total: r.price
+            }));
+
             // Mise à jour de l'affichage
             byId('total-ht').textContent = formatEUR(totalHT);
             byId('total-ttc').textContent = formatEUR(totalTTC);
@@ -959,7 +967,7 @@
             rows.forEach(row => {
                 const tr = document.createElement('tr');
                 const td1 = document.createElement('td');
-                td1.textContent = row.description;
+                td1.textContent = `${row.description} (${row.qty} ${row.unit})`;
                 const td2 = document.createElement('td');
                 td2.className = 'right';
                 td2.textContent = formatEUR(row.price);
@@ -1030,68 +1038,63 @@
                 const { jsPDF } = window.jspdf;
                 const doc = new jsPDF();
 
-                // Header
-                doc.setFillColor(22, 163, 74);
-                doc.rect(0, 0, 210, 40, 'F');
                 doc.setFont('helvetica', 'bold');
-                doc.setFontSize(20);
-                doc.setTextColor(255, 255, 255);
-                doc.text('Devis', 14, 25);
+                doc.setFontSize(18);
+                doc.text('DEVIS', 105, 20, { align: 'center' });
 
-                doc.setFont('helvetica', 'normal');
+                let y = 30;
                 doc.setFontSize(12);
-                doc.setTextColor(0, 0, 0);
-                const clientY = 50;
-                doc.text(`Client : ${byId('name').value}`, 14, clientY);
-                doc.text(`Email : ${byId('email').value}`, 14, clientY + 8);
-                doc.text(`Téléphone : ${byId('phone').value}`, 14, clientY + 16);
+                doc.text('Informations Entreprise', 14, y);
+                y += 6;
+                doc.setFont('helvetica', 'normal');
+                doc.text('Entreprise : Votre SARL BTP', 14, y); y += 6;
+                doc.text('Adresse : 123 Rue Exemple, 34000 Montpellier', 14, y); y += 6;
+                doc.text('Téléphone : 02 00 00 00 00', 14, y); y += 6;
+                doc.text('SIRET : 123 456 789 00010', 14, y); y += 6;
+                doc.text('Assurance décennale : Nom Assurance - Police n°XXXXXX', 14, y); y += 10;
 
-                // Table des prestations
-                const rowsData = Array.from(byId('rows').querySelectorAll('tr')).map(tr => {
-                    const tds = tr.querySelectorAll('td');
-                    return [tds[0].textContent, tds[1].textContent];
-                });
-                let finalY = clientY + 24;
-                if (rowsData.length > 0 && doc.autoTable) {
+                doc.setFont('helvetica', 'bold');
+                doc.text('Informations Client', 14, y);
+                y += 6;
+                doc.setFont('helvetica', 'normal');
+                doc.text(`Nom : ${byId('name').value}`, 14, y); y += 6;
+                doc.text(`Adresse : ${byId('ville').value}`, 14, y); y += 6;
+                doc.text(`Téléphone : ${byId('phone').value}`, 14, y); y += 10;
+
+                doc.setFont('helvetica', 'bold');
+                doc.text('Détails du Devis', 14, y);
+                y += 6;
+
+                if (pdfRows.length > 0 && doc.autoTable) {
                     doc.autoTable({
-                        startY: finalY,
-                        head: [['Description', 'Prix HT']],
-                        body: rowsData,
+                        startY: y,
+                        head: [['Description', 'Quantité', 'PU HT (€)', 'Total HT (€)']],
+                        body: pdfRows.map(r => [r.description, r.qty.toString(), formatEUR(r.unitPrice), formatEUR(r.total)]),
                         styles: { fontSize: 10, cellPadding: 3 },
-                        headStyles: { fillColor: [22, 163, 74], textColor: 255 },
+                        headStyles: { fillColor: [0, 0, 0], textColor: 255 },
                         alternateRowStyles: { fillColor: [245, 245, 245] },
                         theme: 'striped'
                     });
-                    finalY = doc.lastAutoTable.finalY + 10;
+                    y = doc.lastAutoTable.finalY + 10;
                 }
 
-                // Totaux
                 doc.setFontSize(12);
-                doc.text(
-                    `Total HT : ${byId('f-total-ht').textContent}`,
-                    150,
-                    finalY,
-                    { align: 'right' }
-                );
-                doc.text(
-                    `TVA ${byId('tva-rate').textContent} : ${byId('tva-amt').textContent}`,
-                    150,
-                    finalY + 8,
-                    { align: 'right' }
-                );
+                doc.setFont('helvetica', 'normal');
+                doc.text(`Sous-total HT : ${byId('f-total-ht').textContent}`, 196, y, { align: 'right' });
+                doc.text(`TVA (${byId('tva-rate').textContent}) : ${byId('tva-amt').textContent}`, 196, y + 7, { align: 'right' });
                 doc.setFont('helvetica', 'bold');
-                doc.text(
-                    `Total TTC : ${byId('f-total-ttc').textContent}`,
-                    150,
-                    finalY + 16,
-                    { align: 'right' }
-                );
+                doc.setTextColor(220, 38, 38);
+                doc.text(`Total TTC : ${byId('f-total-ttc').textContent}`, 196, y + 14, { align: 'right' });
+                doc.setTextColor(0, 0, 0);
+                y += 26;
 
-                // Footer
                 doc.setFont('helvetica', 'normal');
                 doc.setFontSize(10);
-                doc.setTextColor(120, 120, 120);
-                doc.text('Document généré avec logiciel-devis', 105, 290, { align: 'center' });
+                doc.text('Durée de validité du devis : 30 jours', 14, y); y += 5;
+                doc.text('Prix indiqué : sous réserve d\'évolution du coût des matériaux, ajusté à la commande, selon stock et la livraison.', 14, y, { maxWidth: 182 }); y += 5;
+                doc.text(`TVA applicable : ${byId('tva-rate').textContent}`, 14, y); y += 5;
+                doc.text('Mention légale : 50% d\'acompte à la commande, solde à la livraison.', 14, y, { maxWidth: 182 }); y += 5;
+                doc.text('SRT légales : TVA applicable, RC Pro, coordonnées disponibles sur demande.', 14, y, { maxWidth: 182 });
 
                 doc.save('devis.pdf');
             });


### PR DESCRIPTION
## Summary
- track task quantities and unit prices for PDF export
- redesign generated PDF with enterprise and client information
- show detailed line items and totals matching the desired template

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0fdfc6c9c832a9ad8b947aeda5f00