### PR TITLE
Format HT and TTC prices with two decimal places

### DIFF
--- a/index.html
+++ b/index.html
@@ -718,7 +718,10 @@
         // Formatting utility that avoids locale-specific non breaking spaces
         // to keep PDF output compatible with basic fonts.
         const formatEUR = n => {
-            const value = (n || 0).toFixed(2).replace('.', ',');
+            const value = (n || 0).toLocaleString('fr-FR', {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
+            });
             return `${value} EUR`;
         };
         const byId = id => document.getElementById(id);


### PR DESCRIPTION
## Summary
- use locale-based formatting to ensure HT and TTC values always display two decimal digits

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a19e18860c832a93e69ee90fbdddee