### PR TITLE
Normalize currency spacing for PDF generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -721,7 +721,8 @@
             const value = (n || 0).toLocaleString('fr-FR', {
                 minimumFractionDigits: 2,
                 maximumFractionDigits: 2
-            });
+            })
+                .replace(/[\u202F\u00A0]/g, ' ');
             return `${value} EUR`;
         };
         const byId = id => document.getElementById(id);


### PR DESCRIPTION
## Summary
- Use regular spaces in EUR formatting to match on-screen estimates and ensure PDF compatibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1a04809b8832aa98c6eb5373ea8ee