### PR TITLE
feat: add multisplit AC unit options

### DIFF
--- a/index.html
+++ b/index.html
@@ -655,7 +655,10 @@
             ],
             "Climatisation": [
                 { id: 'clim_monosplit', label: 'Climatiseur monosplit — pose', unit: 'forfait', rate: 1100, min: 1100, hours: 18 },
-                { id: 'clim_multisplit', label: 'Climatiseur multisplit — pose', unit: 'forfait', rate: 2200, min: 2200, hours: 40 },
+                { id: 'clim_multisplit_2ui', label: 'Climatiseur multisplit 2 unités intérieures — pose', unit: 'forfait', rate: 2200, min: 2200, hours: 40 },
+                { id: 'clim_multisplit_3ui', label: 'Climatiseur multisplit 3 unités intérieures — pose', unit: 'forfait', rate: 3300, min: 3300, hours: 60 },
+                { id: 'clim_multisplit_4ui', label: 'Climatiseur multisplit 4 unités intérieures — pose', unit: 'forfait', rate: 4400, min: 4400, hours: 80 },
+                { id: 'clim_multisplit_5ui', label: 'Climatiseur multisplit 5 unités intérieures — pose', unit: 'forfait', rate: 5500, min: 5500, hours: 100 },
                 { id: 'entretien_clim', label: 'Entretien climatisation', unit: 'forfait', rate: 120, min: 120, hours: 2 },
                 { id: 'pompe_a_chaleur', label: 'Pompe à chaleur air/eau', unit: 'forfait', rate: 8500, min: 8500, hours: 80 },
                 { id: 'vmc_double_flux', label: 'VMC double flux', unit: 'forfait', rate: 3200, min: 3200, hours: 35 }


### PR DESCRIPTION
## Summary
- add separate catalogue entries for multisplit air conditioners with 2 to 5 indoor units

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1a61af0c8832a8bcdbf96860ef5cb