### PR TITLE
Add SaaS pricing and basic account system

### DIFF
--- a/account.html
+++ b/account.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>Mon compte</title>
+  <link rel="stylesheet" href="saas.css"/>
+  <script src="https://js.stripe.com/v3"></script>
+  <script>
+    const user = JSON.parse(localStorage.getItem('user') || 'null');
+    if(!user){
+      window.location.href = 'login.html';
+    }
+  </script>
+</head>
+<body>
+  <div class="banner">1 mois gratuit sur l'offre Starter</div>
+  <nav class="navbar">
+    <div>
+      <a href="index.html">Accueil</a>
+    </div>
+    <div>
+      <a href="pricing.html">Tarifs</a>
+      <a href="account.html" class="cta">Mon compte</a>
+    </div>
+  </nav>
+  <div class="container">
+    <h1>Mon compte</h1>
+    <p>Email : <span id="user-email"></span></p>
+    <p>Formule : <span id="user-plan"></span></p>
+    <button id="manage-sub" class="btn-primary">Gérer l'abonnement</button>
+    <button id="logout" class="btn-secondary" style="margin-left:8px">Déconnexion</button>
+  </div>
+<script>
+  const u = JSON.parse(localStorage.getItem('user'));
+  document.getElementById('user-email').textContent = u.email;
+  document.getElementById('user-plan').textContent = u.plan === 'pro' ? 'Pro' : 'Starter';
+  document.getElementById('logout').addEventListener('click', ()=>{
+    localStorage.removeItem('user');
+    window.location.href = 'login.html';
+  });
+  document.getElementById('manage-sub').addEventListener('click', ()=>{
+    // redirection vers le portail Stripe pour gérer l'abonnement
+    fetch('https://example.com/create-portal-session', {method:'POST'})
+      .then(r=>r.json())
+      .then(d=>window.location.href = d.url);
+  });
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,13 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <title>Devis intelligent</title>
+    <link rel="stylesheet" href="saas.css"/>
+    <script>
+        const user = JSON.parse(localStorage.getItem('user') || 'null');
+        if (!user) {
+            window.location.href = 'login.html';
+        }
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
@@ -364,6 +371,11 @@
     </style>
 </head>
 <body>
+    <div class="banner">1 mois gratuit sur l'offre Starter</div>
+    <nav class="navbar">
+        <div><a href="pricing.html">Tarifs</a></div>
+        <div><a href="account.html" class="cta">Mon compte</a></div>
+    </nav>
     <div id="progress-container"><div id="progress-bar"></div></div>
     <div class="container">
         <header>
@@ -1585,7 +1597,15 @@
         function saveArchive(kind, dataUrl) {
             const archives = JSON.parse(localStorage.getItem('archives') || '[]');
             archives.push({ kind, dataUrl, date: new Date().toISOString() });
-            localStorage.setItem('archives', JSON.stringify(archives));
+            const user = JSON.parse(localStorage.getItem('user') || '{}');
+            if (user.plan === 'starter') {
+                const cutoff = new Date();
+                cutoff.setMonth(cutoff.getMonth() - 12);
+                const filtered = archives.filter(a => new Date(a.date) >= cutoff);
+                localStorage.setItem('archives', JSON.stringify(filtered));
+            } else {
+                localStorage.setItem('archives', JSON.stringify(archives));
+            }
         }
 
         function renderArchives() {
@@ -1609,8 +1629,13 @@
         }
 
         const btnInvoice = byId('btn-invoice');
+        const currentUser = JSON.parse(localStorage.getItem('user') || '{}');
         if (btnInvoice) {
-            btnInvoice.addEventListener('click', () => generatePdf('facture'));
+            if (currentUser.plan === 'pro') {
+                btnInvoice.addEventListener('click', () => generatePdf('facture'));
+            } else {
+                btnInvoice.style.display = 'none';
+            }
         }
 
         const btnArchives = byId('btn-archives');

--- a/login.html
+++ b/login.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>Connexion</title>
+  <link rel="stylesheet" href="saas.css"/>
+</head>
+<body>
+  <div class="banner">1 mois gratuit sur l'offre Starter</div>
+  <nav class="navbar">
+    <div>
+      <a href="index.html">Accueil</a>
+    </div>
+    <div>
+      <a href="pricing.html">Tarifs</a>
+    </div>
+  </nav>
+  <div class="container">
+    <h1>Se connecter</h1>
+    <form id="login-form">
+      <div class="form-group">
+        <label>Email</label>
+        <input type="email" id="email" required>
+      </div>
+      <div class="form-group">
+        <label>Mot de passe</label>
+        <input type="password" id="password" required>
+      </div>
+      <div class="form-group">
+        <label><input type="checkbox" id="consent" required> J'accepte le traitement de mes données (RGPD)</label>
+      </div>
+      <button type="submit" class="btn-primary">Connexion</button>
+    </form>
+  </div>
+<script>
+  document.getElementById('login-form').addEventListener('submit', function(e){
+    e.preventDefault();
+    const email = document.getElementById('email').value;
+    const consent = document.getElementById('consent').checked;
+    if(!consent){
+      alert('Veuillez accepter le traitement des données');
+      return;
+    }
+    // sauvegarde utilisateur en local
+    localStorage.setItem('user', JSON.stringify({email: email, plan: 'starter'}));
+    window.location.href = 'index.html';
+  });
+</script>
+</body>
+</html>

--- a/pricing.html
+++ b/pricing.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>Tarifs</title>
+  <link rel="stylesheet" href="saas.css"/>
+  <script src="https://js.stripe.com/v3"></script>
+</head>
+<body>
+  <div class="banner">1 mois gratuit sur l'offre Starter</div>
+  <nav class="navbar">
+    <div>
+      <a href="index.html">Accueil</a>
+    </div>
+    <div>
+      <a href="pricing.html">Tarifs</a>
+      <a href="account.html" class="cta">Mon compte</a>
+    </div>
+  </nav>
+  <div class="container">
+    <h1>Nos offres</h1>
+    <table class="table-pricing">
+      <thead>
+        <tr>
+          <th>Fonctionnalités</th>
+          <th>Starter <span class="badge">1er mois gratuit</span></th>
+          <th>Pro</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>Devis illimités</td><td>✅</td><td>✅</td></tr>
+        <tr><td>Factures illimitées</td><td>❌</td><td>✅</td></tr>
+        <tr><td>Multi‑utilisateurs</td><td>❌</td><td>✅</td></tr>
+        <tr><td>Archivage</td><td>Limité à 12 mois</td><td>Illimité</td></tr>
+        <tr><td>Options avancées</td><td>❌</td><td>✅</td></tr>
+      </tbody>
+    </table>
+    <div style="display:flex;gap:24px;justify-content:center;margin-top:24px;flex-wrap:wrap">
+      <div>
+        <h2>Starter</h2>
+        <p>9,99 € / mois</p>
+        <label><input type="checkbox" id="consent-starter"> J'accepte le traitement de mes données</label>
+        <button class="btn-primary" id="btn-starter">Essayer gratuitement</button>
+      </div>
+      <div>
+        <h2>Pro</h2>
+        <p>19,99 € / mois</p>
+        <label><input type="checkbox" id="consent-pro"> J'accepte le traitement de mes données</label>
+        <button class="btn-secondary" id="btn-pro">Passer en Pro</button>
+      </div>
+    </div>
+  </div>
+<script>
+  const stripe = Stripe('pk_test_12345'); // Remplacer par votre clé publique
+  function subscribe(priceId, consentId){
+    if(!document.getElementById(consentId).checked){
+      alert('Merci de consentir au traitement des données');
+      return;
+    }
+    fetch('https://example.com/create-checkout-session', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({priceId})
+    })
+    .then(r=>r.json())
+    .then(d=>stripe.redirectToCheckout({sessionId:d.sessionId}));
+  }
+  document.getElementById('btn-starter').addEventListener('click',()=>subscribe('price_starter','consent-starter'));
+  document.getElementById('btn-pro').addEventListener('click',()=>subscribe('price_pro','consent-pro'));
+</script>
+</body>
+</html>

--- a/saas.css
+++ b/saas.css
@@ -1,0 +1,91 @@
+:root {
+  --bg: #0b1220;
+  --bg-grad: #1a2333;
+  --fg: #f1f5f9;
+  --muted: #9ca3af;
+  --card: #0f172a;
+  --line: #1f2937;
+  --accent: #22c55e;
+  --danger: #ef4444;
+}
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial;
+  background: radial-gradient(circle at 25% 25%, var(--bg-grad), var(--bg));
+  color: var(--fg);
+}
+.navbar {
+  display:flex;
+  justify-content: space-between;
+  align-items:center;
+  padding:12px 16px;
+  background:var(--card);
+  border-bottom:1px solid var(--line);
+}
+.navbar a {
+  color:var(--fg);
+  margin-left:16px;
+  text-decoration:none;
+}
+.navbar .cta {
+  background:var(--accent);
+  color:#042d17;
+  padding:8px 12px;
+  border-radius:8px;
+}
+.banner {
+  text-align:center;
+  background:var(--accent);
+  color:#042d17;
+  padding:8px;
+  font-weight:700;
+}
+.btn-primary {
+  background: var(--accent);
+  color:#042d17;
+  border:none;
+  padding:10px 16px;
+  border-radius:8px;
+  cursor:pointer;
+}
+.btn-secondary {
+  background:var(--card);
+  border:1px solid var(--line);
+  color:var(--fg);
+  padding:10px 16px;
+  border-radius:8px;
+  cursor:pointer;
+}
+.container {
+  max-width: 800px;
+  margin: 24px auto;
+  padding: 0 16px;
+}
+.table-pricing {
+  width:100%;
+  border-collapse:collapse;
+  margin-top:24px;
+}
+.table-pricing th, .table-pricing td {
+  border:1px solid var(--line);
+  padding:12px;
+  text-align:center;
+}
+.badge {
+  display:inline-block;
+  background:var(--accent);
+  color:#042d17;
+  padding:4px 8px;
+  border-radius:6px;
+  font-size:12px;
+  margin-left:8px;
+}
+.form-group {margin-bottom:16px;}
+input[type="email"], input[type="password"], input[type="text"] {
+  width:100%;
+  padding:10px;
+  border-radius:8px;
+  border:1px solid var(--line);
+  background:var(--card);
+  color:var(--fg);
+}


### PR DESCRIPTION
## Summary
- add pricing page with Starter and Pro plans and Stripe hooks
- provide login and account pages with banner and navigation
- enforce plan restrictions for invoices and archive retention

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b04aab87e4832a9146019a870efdc8