### PR TITLE
Handle navigation based on login status

### DIFF
--- a/account.html
+++ b/account.html
@@ -27,7 +27,7 @@
     </div>
     <div>
       <a href="pricing.html">Tarifs</a>
-      <a href="account.html" class="cta">Mon compte</a>
+      <a id="nav-auth"></a>
     </div>
   </nav>
   <div class="container">
@@ -51,6 +51,17 @@
       .then(r=>r.json())
       .then(d=>window.location.href = d.url);
   });
+
+  const navAuth = document.getElementById('nav-auth');
+  const userNav = JSON.parse(localStorage.getItem('user') || 'null');
+  if (userNav) {
+    navAuth.href = 'account.html';
+    navAuth.textContent = 'Mon compte';
+    navAuth.classList.add('cta');
+  } else {
+    navAuth.href = 'login.html';
+    navAuth.textContent = 'Se connecter';
+  }
 </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -380,7 +380,7 @@
     <div class="banner">1 mois gratuit sur l'offre Starter</div>
     <nav class="navbar">
         <div><a href="pricing.html">Tarifs</a></div>
-        <div><a href="account.html" class="cta">Mon compte</a></div>
+        <div><a id="nav-auth"></a></div>
     </nav>
     <div id="progress-container"><div id="progress-bar"></div></div>
     <div class="container">
@@ -701,6 +701,19 @@
 
     <script>
         document.addEventListener('DOMContentLoaded', function () {
+        const navAuth = document.getElementById('nav-auth');
+        const userNav = JSON.parse(localStorage.getItem('user') || 'null');
+        if (navAuth) {
+            if (userNav) {
+                navAuth.href = 'account.html';
+                navAuth.textContent = 'Mon compte';
+                navAuth.classList.add('cta');
+            } else {
+                navAuth.href = 'login.html';
+                navAuth.textContent = 'Se connecter';
+            }
+        }
+
         // Informations entreprise
         const DEFAULT_COMPANY = {
             name: 'SARL BRUNO MIRA',

--- a/login.html
+++ b/login.html
@@ -5,6 +5,11 @@
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>Connexion</title>
   <link rel="stylesheet" href="saas.css"/>
+  <script>
+    if (localStorage.getItem('user')) {
+      window.location.href = 'account.html';
+    }
+  </script>
 </head>
 <body>
   <div class="banner">1 mois gratuit sur l'offre Starter</div>
@@ -14,6 +19,7 @@
     </div>
     <div>
       <a href="pricing.html">Tarifs</a>
+      <a id="nav-auth"></a>
     </div>
   </nav>
   <div class="container">
@@ -46,6 +52,17 @@
     localStorage.setItem('user', JSON.stringify({email: email, plan: 'starter'}));
     window.location.href = 'index.html';
   });
+
+  const navAuth = document.getElementById('nav-auth');
+  const user = JSON.parse(localStorage.getItem('user') || 'null');
+  if (user) {
+    navAuth.href = 'account.html';
+    navAuth.textContent = 'Mon compte';
+    navAuth.classList.add('cta');
+  } else {
+    navAuth.href = 'login.html';
+    navAuth.textContent = 'Se connecter';
+  }
 </script>
 </body>
 </html>

--- a/pricing.html
+++ b/pricing.html
@@ -15,7 +15,7 @@
     </div>
     <div>
       <a href="pricing.html">Tarifs</a>
-      <a href="account.html" class="cta">Mon compte</a>
+      <a id="nav-auth"></a>
     </div>
   </nav>
   <div class="container">
@@ -68,6 +68,17 @@
   }
   document.getElementById('btn-starter').addEventListener('click',()=>subscribe('price_starter','consent-starter'));
   document.getElementById('btn-pro').addEventListener('click',()=>subscribe('price_pro','consent-pro'));
+
+  const navAuth = document.getElementById('nav-auth');
+  const user = JSON.parse(localStorage.getItem('user') || 'null');
+  if (user) {
+    navAuth.href = 'account.html';
+    navAuth.textContent = 'Mon compte';
+    navAuth.classList.add('cta');
+  } else {
+    navAuth.href = 'login.html';
+    navAuth.textContent = 'Se connecter';
+  }
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Switch navigation link between login and account pages depending on stored user session
- Redirect users away from the login screen if they are already authenticated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b04f65f964832aa2be08cd40ab5762