### PR TITLE
Require subscription before accessing quote interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
         const user = JSON.parse(localStorage.getItem('user') || 'null');
         if (!user) {
             window.location.href = 'login.html';
+        } else if (!user.plan) {
+            window.location.href = 'pricing.html';
         } else {
             const planParam = new URLSearchParams(window.location.search).get('plan');
             if (planParam) {

--- a/login.html
+++ b/login.html
@@ -49,8 +49,8 @@
       return;
     }
     // sauvegarde utilisateur en local
-    localStorage.setItem('user', JSON.stringify({email: email, plan: 'starter'}));
-    window.location.href = 'index.html';
+    localStorage.setItem('user', JSON.stringify({email: email, plan: null}));
+    window.location.href = 'pricing.html';
   });
 
   const navAuth = document.getElementById('nav-auth');


### PR DESCRIPTION
## Summary
- Redirect unauthenticated users without a plan to pricing page before entering quote tool
- After login, store user without plan and send them to pricing to choose an offer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b05160a644832aae4292be1e62e3d0