### PR TITLE
Bypass login to open quote page directly

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,17 +6,17 @@
     <title>Devis intelligent</title>
     <link rel="stylesheet" href="saas.css"/>
     <script>
-        const user = JSON.parse(localStorage.getItem('user') || 'null');
-        if (!user) {
-            window.location.href = 'login.html';
-        } else if (!user.plan) {
-            window.location.href = 'pricing.html';
-        } else {
-            const planParam = new URLSearchParams(window.location.search).get('plan');
-            if (planParam) {
-                user.plan = planParam;
-                localStorage.setItem('user', JSON.stringify(user));
-            }
+        let user = JSON.parse(localStorage.getItem('user') || 'null');
+
+        if (!user || !user.plan) {
+            user = { plan: 'starter' };
+            localStorage.setItem('user', JSON.stringify(user));
+        }
+
+        const planParam = new URLSearchParams(window.location.search).get('plan');
+        if (planParam) {
+            user.plan = planParam;
+            localStorage.setItem('user', JSON.stringify(user));
         }
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- allow direct access to quote page by creating a default starter user instead of redirecting to login

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b18c2a7a68832a808d984fcec202d4