### PR TITLE
Enable send button to prepare callback email

### DIFF
--- a/index.html
+++ b/index.html
@@ -1654,6 +1654,20 @@
             btnInvoice.addEventListener('click', () => generatePdf('facture'));
         }
 
+        const btnSend = byId('btn-send');
+        if (btnSend) {
+            btnSend.addEventListener('click', async function () {
+                await updatePricing();
+                buildRecap();
+                const recapText = byId('recap').innerText;
+                const subject = encodeURIComponent('Demande de devis');
+                const body = encodeURIComponent(
+                    `Bonjour,\n\nVoici ma demande de devis :\n\n${recapText}\n\nMerci de me rappeler au ${byId('phone').value}.`
+                );
+                window.location.href = `mailto:${company.email}?subject=${subject}&body=${body}`;
+            });
+        }
+
         const btnArchives = byId('btn-archives');
         if (btnArchives) {
             btnArchives.addEventListener('click', function () {


### PR DESCRIPTION
## Summary
- add click handler for the "Envoyer & être rappelé" button to generate a callback email containing recap details

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1df06a3cc832a9589bdc4fe19276d