### PR TITLE
Load subtasks from catalog JSON

### DIFF
--- a/index.html
+++ b/index.html
@@ -894,6 +894,25 @@
             ]
         };
 
+        async function hydrateCatalogWithSubtasks() {
+            try {
+                const response = await fetch('subtasks.json', { cache: 'no-store' });
+                if (!response.ok) return;
+                const data = await response.json();
+                if (data && data.subtasks) {
+                    Object.values(CATALOG).forEach(tasks => {
+                        tasks.forEach(task => {
+                            if (data.subtasks[task.id]) {
+                                task.subtasks = data.subtasks[task.id];
+                            }
+                        });
+                    });
+                }
+            } catch (error) {
+                console.warn('Impossible de charger les sous-tâches', error);
+            }
+        }
+
         // Tâches éligibles à la TVA réduite (5,5 %)
         const TVA55_TASKS = new Set([
             'chauffe_eau_200',
@@ -1531,50 +1550,52 @@
             }
         }
 
-        // Initialisation
-        byId('add-task').addEventListener('click', addTaskRow);
-        byId('add-manual-task').addEventListener('click', addManualTaskRow);
-        const optionIds = ['urgence', 'weekend', 'nuit', 'speed', 'pack', 'tva_mode', 'discount_mode', 'duration_mode'];
-        optionIds.forEach(id => {
-            const el = byId(id);
-            if (el) el.addEventListener('change', updatePricing);
-        });
-        const inputIds = ['discount_value', 'manual_days'];
-        inputIds.forEach(id => {
-            const el = byId(id);
-            if (el) el.addEventListener('input', updatePricing);
-        });
+        function initializeInteractions() {
+            byId('add-task').addEventListener('click', addTaskRow);
+            byId('add-manual-task').addEventListener('click', addManualTaskRow);
+            const optionIds = ['urgence', 'weekend', 'nuit', 'speed', 'pack', 'tva_mode', 'discount_mode', 'duration_mode'];
+            optionIds.forEach(id => {
+                const el = byId(id);
+                if (el) el.addEventListener('change', updatePricing);
+            });
+            const inputIds = ['discount_value', 'manual_days'];
+            inputIds.forEach(id => {
+                const el = byId(id);
+                if (el) el.addEventListener('input', updatePricing);
+            });
 
-        function toggleDiscountInput() {
-            const mode = byId('discount_mode').value;
-            byId('discount_value').style.display = mode === 'manual' ? '' : 'none';
-            if (mode !== 'manual') byId('discount_value').value = '';
-        }
-        function toggleDurationInput() {
-            const mode = byId('duration_mode').value;
-            byId('speed-container').style.display = mode === 'manual' ? 'none' : '';
-            byId('manual_days').style.display = mode === 'manual' ? '' : 'none';
-            if (mode !== 'manual') byId('manual_days').value = '';
-        }
-        const discountModeEl = byId('discount_mode');
-        if (discountModeEl) discountModeEl.addEventListener('change', toggleDiscountInput);
-        const durationModeEl = byId('duration_mode');
-        if (durationModeEl) durationModeEl.addEventListener('change', toggleDurationInput);
-        toggleDiscountInput();
-        toggleDurationInput();
-        const siteIds = ['etage', 'ascenseur', 'portage', 'acces', 'stationnement', 'parking_fees', 'engins', 'dechets', 'complexite'];
-        siteIds.forEach(id => {
-            const el = byId(id);
-            if (el) {
-                el.addEventListener('change', updatePricing);
-                el.addEventListener('input', updatePricing);
+            function toggleDiscountInput() {
+                const mode = byId('discount_mode').value;
+                byId('discount_value').style.display = mode === 'manual' ? '' : 'none';
+                if (mode !== 'manual') byId('discount_value').value = '';
             }
-        });
-        const logement2ansEl = byId('logement_2ans');
-        if (logement2ansEl) logement2ansEl.addEventListener('change', updatePricing);
-        const villeEl = byId('ville');
-        if (villeEl) villeEl.addEventListener('input', updatePricing);
-        addTaskRow();
+            function toggleDurationInput() {
+                const mode = byId('duration_mode').value;
+                byId('speed-container').style.display = mode === 'manual' ? 'none' : '';
+                byId('manual_days').style.display = mode === 'manual' ? '' : 'none';
+                if (mode !== 'manual') byId('manual_days').value = '';
+            }
+            const discountModeEl = byId('discount_mode');
+            if (discountModeEl) discountModeEl.addEventListener('change', toggleDiscountInput);
+            const durationModeEl = byId('duration_mode');
+            if (durationModeEl) durationModeEl.addEventListener('change', toggleDurationInput);
+            toggleDiscountInput();
+            toggleDurationInput();
+            const siteIds = ['etage', 'ascenseur', 'portage', 'acces', 'stationnement', 'parking_fees', 'engins', 'dechets', 'complexite'];
+            siteIds.forEach(id => {
+                const el = byId(id);
+                if (el) {
+                    el.addEventListener('change', updatePricing);
+                    el.addEventListener('input', updatePricing);
+                }
+            });
+            const logement2ansEl = byId('logement_2ans');
+            if (logement2ansEl) logement2ansEl.addEventListener('change', updatePricing);
+            const villeEl = byId('ville');
+            if (villeEl) villeEl.addEventListener('input', updatePricing);
+            addTaskRow();
+
+        }
 
         // Génération du récapitulatif
         function buildRecap() {
@@ -1858,7 +1879,13 @@
         document.addEventListener('scroll', updateProgressBar);
         updateProgressBar();
 
-        renderCompany();
+        async function initApp() {
+            await hydrateCatalogWithSubtasks();
+            initializeInteractions();
+            renderCompany();
+        }
+
+        initApp();
         });
     </script>
 </body>

--- a/subtasks.json
+++ b/subtasks.json
@@ -1,0 +1,710 @@
+{
+  "meta": {
+    "language": "fr",
+    "version": "1.0"
+  },
+  "subtasks": {
+    "maison_surface": [
+      "Implantation générale et organisation du chantier.",
+      "Coordination gros œuvre, second œuvre et finitions.",
+      "Gestion des réseaux (eau, électricité, évacuations) jusqu’aux attentes intérieures.",
+      "Pose des menuiseries extérieures et étanchéité à l’air/eau des points sensibles.",
+      "Contrôles de conformité et remise d’un chantier propre."
+    ],
+    "maison_chambre": [
+      "Préparation des supports (sols/murs/plafond) avant finitions.",
+      "Création/ajustement des cloisons et passages de réseaux.",
+      "Finitions peintes et pose des menuiseries intérieures.",
+      "Pose du revêtement de sol et plinthes.",
+      "Nettoyage et remise en état."
+    ],
+    "maison_cuisine": [
+      "Préparation murs et arrivées/évacuations adaptées à la cuisine.",
+      "Implantation des caissons et plans de travail.",
+      "Intégration des points lumineux et prises dédiées.",
+      "Pose des habillages/finissions (crédence, joints, ajustements).",
+      "Nettoyage et vérifications de fonctionnement."
+    ],
+    "maison_sdb": [
+      "Préparation supports et étanchéité des zones humides.",
+      "Implantation des arrivées/évacuations et appareillages.",
+      "Pose des revêtements (murs/sol) adaptés à l’humide.",
+      "Mise en place des sanitaires et robinetteries.",
+      "Tests d’écoulement/étanchéité et nettoyage."
+    ],
+    "maison_salon": [
+      "Préparation et mise à niveau des supports.",
+      "Passage/ajustement des réseaux (prises, éclairages, données).",
+      "Finitions peintes et pose du revêtement de sol.",
+      "Pose des habillages (plinthes, seuils) et retouches.",
+      "Nettoyage final."
+    ],
+    "dalle_beton": [
+      "Préparation du support et réglage des niveaux.",
+      "Coffrage simple et mise en place des couches prévues.",
+      "Coulage et tirage du béton.",
+      "Surfaçage et protection durant la prise.",
+      "Nettoyage périphérique."
+    ],
+    "ouverture_porteur": [
+      "Étaiement et sécurisation de la zone.",
+      "Traçage et découpe contrôlée de l’ouverture.",
+      "Mise en place et scellement de la poutre/IPN.",
+      "Reprises des appuis et finitions brutes prêtes à enduire.",
+      "Évacuation des déblais et nettoyage."
+    ],
+    "demolition_cloison": [
+      "Protection des accès et sols.",
+      "Dépose maîtrisée de la cloison.",
+      "Conditionnement et évacuation des gravats.",
+      "Rebouchages simples aux raccords.",
+      "Nettoyage de fin d’intervention."
+    ],
+    "mur_agglo": [
+      "Implantation et traçage.",
+      "Montage des rangs avec réglage aplomb/niveau.",
+      "Intégration des réservations simples.",
+      "Reprises de rives et liaisons aux existants.",
+      "Nettoyage et repli."
+    ],
+    "chape_liquide": [
+      "Préparation du support et bandes périphériques.",
+      "Réglage des niveaux et contrôle d’épaisseur.",
+      "Coulage de la chape et dégazage.",
+      "Cure/séchage selon recommandations.",
+      "Nettoyage périphérique."
+    ],
+    "seuil_beton": [
+      "Implantation et coffrage localisé.",
+      "Coulage et mise à niveau.",
+      "Finition de surface.",
+      "Décoffrage et nettoyage."
+    ],
+    "fondations_semelles": [
+      "Traçage et fouilles aux dimensions prévues.",
+      "Mise en place du lit de pose/armatures simples.",
+      "Coulage du béton et réglage altimétrique.",
+      "Protection pendant prise et nettoyage de zone."
+    ],
+    "muret_cloture": [
+      "Implantation sur ligne et altimétrie.",
+      "Montage du muret et contrôles d’alignement.",
+      "Réservations/renforts ponctuels si nécessaire.",
+      "Finition brute prête à enduire ou chapeauter.",
+      "Repli et nettoyage."
+    ],
+    "ragreage_sol": [
+      "Dépoussiérage et primaire d’adhérence si nécessaire.",
+      "Préparation des niveaux et mélange du produit.",
+      "Application du ragréage et marouflage.",
+      "Séchage contrôlé.",
+      "Nettoyage des abords."
+    ],
+    "escalier_beton": [
+      "Traçage et coffrage des marches.",
+      "Mise en place des armatures prévues.",
+      "Coulage et talochage soigneux.",
+      "Décoffrage et ébavurage.",
+      "Nettoyage et protection durant la prise."
+    ],
+    "mur_pierre": [
+      "Sélection et préparation des pierres.",
+      "Implantation et montage soigné par assises.",
+      "Calage et contrôle de verticalité.",
+      "Couronnement et finitions.",
+      "Nettoyage du site."
+    ],
+    "reseau_ecs": [
+      "Traçage des parcours et perçages propres.",
+      "Pose des canalisations et fixations.",
+      "Raccordements et essais d’étanchéité.",
+      "Isolation/repérage des lignes.",
+      "Nettoyage et repli."
+    ],
+    "sdb_pack": [
+      "Préparation et étanchéité des zones d’eau.",
+      "Positionnement des arrivées/évacuations.",
+      "Pose des appareils (douche/baignoire, vasque, WC si prévu).",
+      "Raccordements, réglages et essais.",
+      "Nettoyage et remise en état."
+    ],
+    "wc_suspendu": [
+      "Préparation du support et bâti‑support.",
+      "Raccordements alimentation/évacuation.",
+      "Habillage et finitions apparentes.",
+      "Pose de la cuvette/plaque de commande.",
+      "Tests de fonctionnement et nettoyage."
+    ],
+    "chauffe_eau_200": [
+      "Mise en place et fixation sécurisée.",
+      "Raccordements hydrauliques et groupe de sécurité.",
+      "Raccordement électrique si prévu.",
+      "Mise en eau et tests de chauffe.",
+      "Explications d’usage et nettoyage."
+    ],
+    "evac_eu": [
+      "Traçage du réseau et pentes.",
+      "Pose des canalisations et raccords.",
+      "Étanchéité des assemblages.",
+      "Essais d’écoulement.",
+      "Repli et nettoyage."
+    ],
+    "receveur_douche": [
+      "Préparation du support et siphon.",
+      "Réglage des niveaux et encollage.",
+      "Pose du receveur et étanchéité périphérique.",
+      "Tests d’écoulement.",
+      "Nettoyage de la zone."
+    ],
+    "chaudiere_gaz": [
+      "Positionnement et fixations.",
+      "Raccordements gaz/eau/évacuations.",
+      "Ventouse/évacuation des fumées.",
+      "Mise sous pression et essais d’étanchéité.",
+      "Mise en service par technicien agréé (si requis)."
+    ],
+    "raccordement_evier": [
+      "Raccordements alimentation/évacuation sous évier.",
+      "Pose siphon et joints.",
+      "Tests d’étanchéité et écoulement.",
+      "Nettoyage et repli."
+    ],
+    "pose_lavabo": [
+      "Fixation console/meuble.",
+      "Raccordements eau/évacuation.",
+      "Pose robinetterie et joints.",
+      "Tests et nettoyage."
+    ],
+    "debouchage_canalisation": [
+      "Diagnostic localisé.",
+      "Intervention mécanique/chimique adaptée.",
+      "Rinçage et contrôle d’écoulement.",
+      "Conseils d’entretien."
+    ],
+    "renov_t2": [
+      "Repérage des circuits et mise en sécurité.",
+      "Création/ajustement des lignes et protections.",
+      "Pose d’appareillages (prises, interrupteurs, éclairages).",
+      "Remplacement ou mise à niveau du tableau si nécessaire.",
+      "Tests de conformité et étiquetage."
+    ],
+    "prise": [
+      "Traçage de l’emplacement.",
+      "Passage de la gaine et tirage des conducteurs.",
+      "Pose boîtier et appareillage.",
+      "Raccordements et tests."
+    ],
+    "spots": [
+      "Traçage et perçage propres.",
+      "Câblage et connexion sécurisée.",
+      "Pose des spots et finitions affleurantes.",
+      "Essais d’allumage et contrôle d’échauffement."
+    ],
+    "tableau": [
+      "Mise hors tension et sécurisation.",
+      "Transfert des circuits et protections adaptées.",
+      "Raccordements, étiquetage et essais DDR.",
+      "Remise sous tension et contrôle final."
+    ],
+    "point_lumineux": [
+      "Création ou reprise de l’alimentation.",
+      "Fixation du luminaire.",
+      "Raccordement et essai.",
+      "Nettoyage de la zone."
+    ],
+    "vmc_simple": [
+      "Implantation caisson et bouches.",
+      "Passage des gaines et sorties.",
+      "Raccordement électrique.",
+      "Réglage des débits et essais."
+    ],
+    "prise_exterieure": [
+      "Choix d’un emplacement protégé.",
+      "Passage de gaine adaptée.",
+      "Pose boîtier/IP55 et raccordement.",
+      "Tests et étiquetage."
+    ],
+    "mise_terre": [
+      "Contrôle de la prise de terre existante.",
+      "Pose/liaison du conducteur principal et liaisons équipotentielles.",
+      "Mesure de résistance de terre.",
+      "Compte‑rendu des valeurs."
+    ],
+    "chauffage_electrique": [
+      "Fixation murale sécurisée.",
+      "Raccordement électrique.",
+      "Mise en route et réglages basiques.",
+      "Explications d’usage."
+    ],
+    "domotique_centrale": [
+      "Implantation et alimentation sécurisée.",
+      "Appariage des modules.",
+      "Configuration scénarios de base.",
+      "Tests de commande et sauvegarde."
+    ],
+    "sol_interieur": [
+      "Préparation du support et primaire si nécessaire.",
+      "Calepinage simple et traçage axes.",
+      "Pose des carreaux et croisillons.",
+      "Jointoiement et nettoyage final."
+    ],
+    "terrasse": [
+      "Préparation support/pendage vers évacuations.",
+      "Calepinage et pose adaptée extérieur.",
+      "Réalisation des joints hydrofuges.",
+      "Nettoyage et protections initiales."
+    ],
+    "credence": [
+      "Préparation du mur.",
+      "Pose des carreaux et découpes propres.",
+      "Jointoiement soigné.",
+      "Nettoyage et lustrage léger."
+    ],
+    "faience": [
+      "Préparation du support.",
+      "Pose du bas vers le haut et alignements.",
+      "Joints et finitions périphériques.",
+      "Nettoyage."
+    ],
+    "plinthes_carrelage": [
+      "Découpes et ajustements.",
+      "Collage/pose en périphérie.",
+      "Joints haut/bas si nécessaires.",
+      "Nettoyage."
+    ],
+    "escalier_carrelage": [
+      "Prises de gabarits.",
+      "Pose marches/contre‑marches antidérapantes.",
+      "Joints et baguettes nez de marche.",
+      "Nettoyage."
+    ],
+    "pose_mosaique": [
+      "Préparation et alignement des trames.",
+      "Pose soignée et marouflage.",
+      "Joint fin adapté.",
+      "Nettoyage final."
+    ],
+    "carrelage_mural_sdb": [
+      "Préparation support et étanchéité locale.",
+      "Pose avec découpes autour équipements.",
+      "Joints hydrofuges.",
+      "Nettoyage."
+    ],
+    "joint_carrelage": [
+      "Nettoyage préalable des interstices.",
+      "Application du joint et lissage.",
+      "Épongeage et finitions.",
+      "Lustrage après prise."
+    ],
+    "murs_plafonds": [
+      "Protection complète des zones non peintes.",
+      "Préparation des supports (rebouchage/ponçage/nettoyage).",
+      "Application de la sous‑couche si nécessaire.",
+      "Application des couches de finition.",
+      "Retouches et remise en état."
+    ],
+    "boiseries_laque": [
+      "Dépose/masquage des quincailleries.",
+      "Dégraissage, égrenage et dépoussiérage.",
+      "Application d’impression puis laque de finition.",
+      "Remontage et retouches fines."
+    ],
+    "enduit_lissage": [
+      "Diagnostic des défauts.",
+      "Application des passes d’enduit.",
+      "Ponçage et contrôle à la lumière rasante.",
+      "Dépoussiérage final."
+    ],
+    "peinture_facade": [
+      "Nettoyage du support et réparations localisées.",
+      "Protection des abords.",
+      "Application couche(s) selon préconisation.",
+      "Contrôle d’uniformité et nettoyage du site."
+    ],
+    "papier_peint": [
+      "Préparation des murs.",
+      "Encollage et pose lé par lé.",
+      "Alignements et coupes en haut/bas.",
+      "Nettoyage et lissage final."
+    ],
+    "peinture_anti_humidite": [
+      "Nettoyage et traitement préparatoire.",
+      "Application du système adapté.",
+      "Ventilation/séchage contrôlé.",
+      "Retouches et nettoyage."
+    ],
+    "peinture_boiseries_ext": [
+      "Décapage léger/ponçage.",
+      "Protection des zones adjacentes.",
+      "Application système extérieur adapté.",
+      "Contrôle et retouches."
+    ],
+    "peinture_radiateur": [
+      "Dépose/masquage selon accès.",
+      "Dégraissage et préparation.",
+      "Application peinture haute tenue.",
+      "Remise en place et nettoyage."
+    ],
+    "porte_interieure": [
+      "Dépose de l’existant si prévu.",
+      "Calage et fixation du bloc‑porte.",
+      "Pose de la quincaillerie.",
+      "Réglages d’ouvrant et finitions."
+    ],
+    "fenetre_pvc": [
+      "Dépose de l’ancienne menuiserie si prévu.",
+      "Mise en place du dormant et fixations.",
+      "Pose de l’ouvrant et étanchéité périphérique.",
+      "Réglages et finitions intérieures."
+    ],
+    "volet_roulant": [
+      "Pose du coffre et coulisses.",
+      "Raccordement et essais de montée/descente.",
+      "Réglage des fins de course.",
+      "Explications d’usage."
+    ],
+    "parquet_flottant": [
+      "Vérification planéité et sous‑couche.",
+      "Pose en quinconce avec jeux de dilatation.",
+      "Pose plinthes/barres de seuil.",
+      "Nettoyage final."
+    ],
+    "placard_sur_mesure": [
+      "Relevé et préparation du volume.",
+      "Pose des caissons et aménagements.",
+      "Pose portes/coulissants et réglages.",
+      "Finitions visibles et nettoyage."
+    ],
+    "escalier_bois": [
+      "Traçage et prises d’appuis.",
+      "Pose de la structure et fixations.",
+      "Réglages des marches/garde‑corps.",
+      "Finitions et nettoyage."
+    ],
+    "fenetre_aluminium": [
+      "Dépose/pose selon configuration.",
+      "Calage, fixation et étanchéité périphérique.",
+      "Réglages de l’ouvrant.",
+      "Finitions intérieures."
+    ],
+    "cloison_ba13": [
+      "Implantation et pose de l’ossature.",
+      "Mise en place de l’isolant si prévu.",
+      "Vissage des plaques et traitements de joints.",
+      "Ponçage léger et nettoyage."
+    ],
+    "doublage_isolant": [
+      "Pose rails/montants.",
+      "Mise en place des panneaux isolants.",
+      "Fermeture par plaques et joints.",
+      "Ponçage et dépoussiérage."
+    ],
+    "plafond_suspendu": [
+      "Repérage des niveaux et suspentes.",
+      "Pose ossature/fourrures.",
+      "Pose plaques et trappes si nécessaires.",
+      "Joints, ponçage et nettoyage."
+    ],
+    "corniche_staff": [
+      "Traçage et coupes adaptées.",
+      "Collage/pose soignée.",
+      "Jointoiement et finitions.",
+      "Nettoyage."
+    ],
+    "joint_placo": [
+      "Pose bandes.",
+      "Application passes d’enduit.",
+      "Ponçage et inspection.",
+      "Dépoussiérage final."
+    ],
+    "cloison_acoustique": [
+      "Pose ossature avec bandes résilientes.",
+      "Mise en place isolant acoustique.",
+      "Fermeture double peau et joints.",
+      "Contrôle et nettoyage."
+    ],
+    "reparation_fissures": [
+      "Ouverture/curage de la fissure.",
+      "Traitement et rebouchage adapté.",
+      "Ponçage/retouche de finition.",
+      "Nettoyage."
+    ],
+    "toiture_tuile": [
+      "Mise en place écran sous‑toiture.",
+      "Pose liteaux et tuiles selon calepinage.",
+      "Traitement faîtage/rives.",
+      "Contrôle d’étanchéité visible et nettoyage."
+    ],
+    "reparation_fuite": [
+      "Recherche de l’origine de la fuite.",
+      "Remplacement/étanchéité des éléments en cause.",
+      "Contrôle des points sensibles.",
+      "Nettoyage et repli."
+    ],
+    "pose_gouttiere": [
+      "Traçage des pentes.",
+      "Pose crochets et développés.",
+      "Assemblages/étanchéité des jonctions.",
+      "Tests d’écoulement."
+    ],
+    "demoussage_toiture": [
+      "Protection alentours.",
+      "Brossage/nettoyage mécanique.",
+      "Application traitement anti‑mousse.",
+      "Rinçage contrôlé."
+    ],
+    "reprise_faitiere": [
+      "Dépose partielle des éléments.",
+      "Reprise scellée/à sec selon système.",
+      "Étanchéité et alignements.",
+      "Nettoyage de la zone."
+    ],
+    "pose_velux": [
+      "Traçage et découpe du chevêtre.",
+      "Pose du dormant et abergements.",
+      "Intégration couverture et étanchéité.",
+      "Réglages de l’ouvrant et finitions intérieures."
+    ],
+    "isolation_toiture": [
+      "Pose suspentes/contre‑lattage.",
+      "Mise en place des isolants.",
+      "Traitement pare‑vapeur/étanchéité à l’air.",
+      "Fermeture et finitions brutes."
+    ],
+    "isolation_combles": [
+      "Balisage et protection des accès.",
+      "Préparation du plancher/pare‑vapeur.",
+      "Soufflage de l’isolant à l’épaisseur prévue.",
+      "Repli et nettoyage."
+    ],
+    "isolation_murs": [
+      "Pose ossature et isolant.",
+      "Pare‑vapeur si nécessaire.",
+      "Fermeture par plaques et joints.",
+      "Nettoyage."
+    ],
+    "isolation_plancher": [
+      "Préparation des supports.",
+      "Pose isolant sous‑face ou panneaux.",
+      "Traitement des ponts thermiques courants.",
+      "Nettoyage."
+    ],
+    "isolation_exterieure": [
+      "Collage/chevillage des panneaux.",
+      "Traitement des angles/encadrements.",
+      "Sous‑enduit et marouflage.",
+      "Finition prête à peindre/enduit décoratif."
+    ],
+    "etancheite_air": [
+      "Pose des membranes et adhésifs.",
+      "Traitement soigné des percements.",
+      "Contrôle de continuité.",
+      "Nettoyage."
+    ],
+    "isolation_phonique": [
+      "Mise en place isolants et bandes résilientes.",
+      "Fermeture double peau si prévu.",
+      "Traitement des joints périphériques.",
+      "Nettoyage."
+    ],
+    "depose_isolation": [
+      "Protection et confinement léger.",
+      "Dépose/conditionnement des matériaux.",
+      "Évacuation en filière adaptée.",
+      "Nettoyage de la zone."
+    ],
+    "clim_monosplit": [
+      "Repérage des emplacements.",
+      "Percement et passage des liaisons.",
+      "Pose des unités et fixations.",
+      "Raccordements électriques et condensats.",
+      "Essais de base (avant mise en service certifiée si requise)."
+    ],
+    "clim_multisplit_2ui": [
+      "Étude des tracés multi‑liaisons.",
+      "Pose unité extérieure et 2 unités intérieures.",
+      "Raccordements et tirage au vide (si prévu).",
+      "Essais fonctionnels pré‑MS."
+    ],
+    "clim_multisplit_3ui": [
+      "Implantation et percements dédiés.",
+      "Pose des 3 UI et de l’UE.",
+      "Raccordements et essais pré‑MS.",
+      "Nettoyage et repli."
+    ],
+    "clim_multisplit_4ui": [
+      "Organisation des liaisons et réservations.",
+      "Pose des 4 UI et de l’UE.",
+      "Raccordements/essais pré‑MS.",
+      "Nettoyage du site."
+    ],
+    "clim_multisplit_5ui": [
+      "Plan de passage et percements multiples.",
+      "Pose des 5 UI et de l’UE.",
+      "Raccordements/essais pré‑MS.",
+      "Nettoyage et repli."
+    ],
+    "entretien_clim": [
+      "Nettoyage filtres/évaporateur/condenseur.",
+      "Contrôle visuel des liaisons.",
+      "Test des températures et fonctionnement.",
+      "Recommandations d’usage."
+    ],
+    "pompe_a_chaleur": [
+      "Implantation unité(s) et hydraulique.",
+      "Raccordements eau/électricité.",
+      "Mise en eau/pression et essais.",
+      "Paramétrage de base et vérifications."
+    ],
+    "vmc_double_flux": [
+      "Implantation centrale et réseaux.",
+      "Pose des bouches insufflation/extraction.",
+      "Raccordements et équilibrage.",
+      "Essais de débit."
+    ],
+    "remplacement_filtre": [
+      "Dépose des filtres usagés.",
+      "Nettoyage des logements.",
+      "Pose des filtres neufs.",
+      "Essais et remise à zéro éventuelle."
+    ],
+    "diagnostic_panne": [
+      "Contrôle visuel et tests de base.",
+      "Vérification alimentations/commandes.",
+      "Rapport synthétique des pistes.",
+      "Conseils de remise en service."
+    ],
+    "decaissement": [
+      "Balisage et protection.",
+      "Décaissement à la profondeur prévue.",
+      "Mise en forme générale.",
+      "Nivellement et repli."
+    ],
+    "tranchee_technique": [
+      "Traçage et ouverture de tranchée.",
+      "Pose lit de pose et gaines.",
+      "Remblaiement par couches.",
+      "Compactage et nettoyage."
+    ],
+    "drainage_peripherique": [
+      "Ouverture au pied des fondations.",
+      "Pose drains et géotextile.",
+      "Réglage des pentes vers exutoire.",
+      "Remblaiement et remise en état."
+    ],
+    "evacuation_deblais": [
+      "Chargement et transport adaptés.",
+      "Dépose en filière autorisée.",
+      "Nettoyage des accès.",
+      "Repli."
+    ],
+    "couche_forme_tout_venant": [
+      "Apport et étalement du matériau.",
+      "Réglage altimétrique.",
+      "Compactage mécanique.",
+      "Nettoyage périphérique."
+    ],
+    "remblaiement": [
+      "Apport et étalement par couches.",
+      "Compactage progressif.",
+      "Mise à niveau finale.",
+      "Nettoyage de zone."
+    ],
+    "puits_perdu": [
+      "Implantation et creusement localisé.",
+      "Pose du puits/drain et remplissage filtrant.",
+      "Raccordements éventuels.",
+      "Remise en état du terrain."
+    ],
+    "mur_soutenement": [
+      "Terrassement/semelle adaptée.",
+      "Montage/armatures selon système.",
+      "Drainage arrière et barbacanes.",
+      "Remblaiement et finitions brutes."
+    ],
+    "porte_blindee": [
+      "Dépose de la porte existante si prévu.",
+      "Pose du bloc et fixations renforcées.",
+      "Réglage de la serrure et des paumelles.",
+      "Contrôles d’alignement/fermeture."
+    ],
+    "grille_securite": [
+      "Prises d’appuis et fixations.",
+      "Pose de la grille et ancrages.",
+      "Contrôle rigidité et alignements.",
+      "Nettoyage."
+    ],
+    "rideau_metal": [
+      "Pose des coulisses et axe.",
+      "Mise en place du tablier.",
+      "Raccordements et réglage fins de course.",
+      "Essais ouverture/fermeture."
+    ],
+    "serrure_3points": [
+      "Dépose de l’ancienne serrure.",
+      "Pose serrure et tringles.",
+      "Réglage gâches/alignements.",
+      "Tests de fonctionnement."
+    ],
+    "depannage_serrurerie": [
+      "Diagnostic rapide de la situation.",
+      "Ouverture non destructive si possible.",
+      "Réglages/recodage simple si nécessaire.",
+      "Conseils de sécurisation."
+    ],
+    "garde_corps": [
+      "Prises d’aplomb et percements.",
+      "Fixations mécaniques/chimiques.",
+      "Pose des modules/longrines.",
+      "Contrôle de sécurité."
+    ],
+    "motorisation_portail": [
+      "Pose du moteur et supports.",
+      "Raccordements et cellules de sécurité.",
+      "Réglages course/vitesse.",
+      "Tests et consignes d’utilisation."
+    ],
+    "pose_gazon": [
+      "Préparation du sol et nivellement.",
+      "Pose des plaques de gazon.",
+      "Roulage et arrosage initial.",
+      "Conseils d’entretien de reprise."
+    ],
+    "cloture_rigide": [
+      "Implantation des poteaux et scellements.",
+      "Pose des panneaux et accessoires.",
+      "Alignements et tensions.",
+      "Nettoyage du site."
+    ],
+    "allee_pavee": [
+      "Décaissement et couche de forme.",
+      "Pose du lit de pose et calepinage.",
+      "Pose des pavés et compactage.",
+      "Jointoiement et nettoyage."
+    ],
+    "terrasse_bois": [
+      "Implantation et plots/solives.",
+      "Pose des lames et fixations.",
+      "Traitement des rives et finitions.",
+      "Nettoyage et conseils d’entretien."
+    ],
+    "abri_jardin": [
+      "Implantation et ancrages.",
+      "Montage des parois/toiture.",
+      "Pose menuiseries et quincailleries.",
+      "Finitions et nettoyage."
+    ],
+    "pergola_bois": [
+      "Implantation et scellements/pieds.",
+      "Montage de la structure.",
+      "Fixations et contreventements.",
+      "Finitions et repli."
+    ],
+    "eclairage_jardin": [
+      "Traçage des lignes et fourreaux.",
+      "Pose des luminaires/bornes.",
+      "Raccordements et tests.",
+      "Réglages et nettoyage."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- fetch the subtasks catalog at runtime and merge it into the existing task catalog so every task exposes its detailed steps
- defer UI task initialization until the subtasks have been applied, ensuring the selector displays the complete list

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d91627412c832a88a7ab56666f68c4