### PR TITLE
Fix subtask hydration to restore task creation

### DIFF
--- a/index.html
+++ b/index.html
@@ -928,7 +928,6 @@
         };
 
         async function hydrateCatalogWithSubtasks() {
- codex/developper-un-site-web-pour-un-client-88l5s0
             const applySubtasks = (library, sourceLabel) => {
                 if (!library) return false;
                 const mapping = library.subtasks && typeof library.subtasks === 'object'
@@ -976,23 +975,6 @@
 
             if (!subtasksLoaded) {
                 console.warn("Aucune sous-tâche n'a pu être chargée. Vérifiez subtasks.json ou subtasks.js.");
-
-            try {
-                const response = await fetch('subtasks.json', { cache: 'no-store' });
-                if (!response.ok) return;
-                const data = await response.json();
-                if (data && data.subtasks) {
-                    Object.values(CATALOG).forEach(tasks => {
-                        tasks.forEach(task => {
-                            if (data.subtasks[task.id]) {
-                                task.subtasks = data.subtasks[task.id];
-                            }
-                        });
-                    });
-                }
-            } catch (error) {
-                console.warn('Impossible de charger les sous-tâches', error);
- main
             }
         }
 


### PR DESCRIPTION
## Summary
- clean up the subtask hydration helper so that catalog loading no longer throws runtime errors
- ensure the app falls back to the embedded library and only warns when no subtasks are available

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d95bfab108832abc5fd5833a4d0ffd